### PR TITLE
[Fix]tensorflowのバージョンと種類を変更

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -51,10 +51,10 @@ requests-oauthlib==1.3.1
 rsa==4.8
 six==1.16.0
 SQLAlchemy==1.4.32
-tensorboard==2.7.0
+tensorboard==2.8.0
 tensorboard-data-server==0.6.1
 tensorboard-plugin-wit==1.8.1
-tensorflow==2.8.0rc0
+tensorflow-cpu==2.8.0
 tensorflow-io-gcs-filesystem==0.24.0
 termcolor==1.1.0
 tf-estimator-nightly==2.8.0.dev2021122109


### PR DESCRIPTION
`tensorflow==2.8.0rc0`　＝＞　`tensorflow-cpu==2.8.0`

※ tensorflowはデータ量(M)が多い為。